### PR TITLE
DB関連部分も環境変数で渡す

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: postgresql
   encoding: unicode
   username: postgres
-  password: password
+  password: ENV["POSTGRES_PASSWORD"]
   host: db
   pool: 5
 development:


### PR DESCRIPTION
DBのpasswordを環境変数で渡す記述に修正しました。

```ruby:database.yml
password: ENV["POSTGRES_PASSWORD"]
```